### PR TITLE
fix: fix exponent

### DIFF
--- a/script/ExactlySchedule.s.sol
+++ b/script/ExactlySchedule.s.sol
@@ -56,7 +56,7 @@ contract ExactlyScheduleScript is BaseScript {
 
     function getSegment(uint128 amount, uint40 milestone) public pure returns (LockupDynamic.Segment memory) {
         LockupDynamic.Segment memory segment =
-            LockupDynamic.Segment({ amount: amount, milestone: milestone, exponent: ud2x18(1) });
+            LockupDynamic.Segment({ amount: amount, milestone: milestone, exponent: ud2x18(1e18) });
         return segment;
     }
 


### PR DESCRIPTION
The exponent should be `ud2x18(1e18)` (1 in normal numbers) not `ud2x18(1)` (1e-18 in normal numbers). From the [docs](https://docs.sablier.com/concepts/protocol/segments):

> Because x is a percentage, the streaming rate is inversely proportional to the exponent. For example, if the exponent is 0.5, the rate is quadratically faster compared to the baseline when the exponent is 1. Conversely, if exponent is 2, the rate is quadratically slower compared to baseline.